### PR TITLE
Updated GET method for AFNetworking 2.0

### DIFF
--- a/Example/IOSLinkedInAPI-Example/IOSLinkedInAPI-Example/LIAViewController.m
+++ b/Example/IOSLinkedInAPI-Example/IOSLinkedInAPI-Example/LIAViewController.m
@@ -45,7 +45,7 @@
     [self.client getAuthorizationCode:^(NSString *code) {
         [self.client getAccessToken:code success:^(NSDictionary *accessTokenData) {
             NSString *accessToken = [accessTokenData objectForKey:@"access_token"];
-            [self.client getPath:[NSString stringWithFormat:@"https://api.linkedin.com/v1/people/~?oauth2_access_token=%@&format=json", accessToken] parameters:nil success:^(AFHTTPRequestOperation *operation, NSDictionary *result) {
+            [self.client GET:[NSString stringWithFormat:@"https://api.linkedin.com/v1/people/~?oauth2_access_token=%@&format=json", accessToken] parameters:nil success:^(AFHTTPRequestOperation *operation, NSDictionary *result) {
                 NSLog(@"current user %@", result);
             }            failure:^(AFHTTPRequestOperation *operation, NSError *error) {
                 NSLog(@"failed to fetch current user %@", error);


### PR DESCRIPTION
This should fix an error that occurs when you try to build the example app.
