### PR TITLE
extract error description from url

### DIFF
--- a/IOSLinkedInAPI/LIALinkedInAuthorizationViewController.m
+++ b/IOSLinkedInAPI/LIALinkedInAuthorizationViewController.m
@@ -106,7 +106,11 @@ BOOL handlingRedirectURL;
             if (accessDenied) {
                 self.cancelCallback();
             } else {
-                NSError *error = [[NSError alloc] initWithDomain:kLinkedInErrorDomain code:1 userInfo:[[NSMutableDictionary alloc] init]];
+                NSString* errorDescription = [self extractGetParameter:@"error_description" fromURLString:url];
+                NSError *error = [[NSError alloc] initWithDomain:kLinkedInErrorDomain
+                                                            code:1
+                                                        userInfo:@{
+                                                                   NSLocalizedDescriptionKey: errorDescription}];
                 self.failureCallback(error);
             }
         } else {


### PR DESCRIPTION
When there is an error with the request, the error is extracted from the url and then added to the userInfo of the returned `NSError*`