### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ How To Get Started
 ------------------
 The library can be fetched as a Pod from [cocoapods](http://cocoapods.org/?q=ioslinkedinapi)
 
-If you aren't using Cocoapods you can always download the libary and import the files from the folder IOSLinkedInAPI into your existing project.
+If you aren't using CocoaPods you can always download the libary and import the files from the folder IOSLinkedInAPI into your existing project.
 
 Example Code
 ------------


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
