### PR TITLE
Update LIALinkedInAuthorizationViewController.m

### DIFF
--- a/IOSLinkedInAPI/LIALinkedInAuthorizationViewController.m
+++ b/IOSLinkedInAPI/LIALinkedInAuthorizationViewController.m
@@ -116,7 +116,7 @@ BOOL handlingRedirectURL;
         } else {
             NSString *receivedState = [self extractGetParameter:@"state" fromURLString: url];
             //assert that the state is as we expected it to be
-            if ([self.application.state isEqualToString:receivedState]) {
+            if ([receivedState containsString:self.application.state]) {
                 //extract the code from the url
                 NSString *authorizationCode = [self extractGetParameter:@"code" fromURLString: url];
                 self.successCallback(authorizationCode);


### PR DESCRIPTION
As of today, the receivedState parameter has extra characters appended to it, and therefore does not match the original state.  

For example, my state is "ABCDE"
The returned state is "ABCDE#!"

This fix keeps the state matching in tact in case extra chars are appended to the end.